### PR TITLE
feat: update listview to only show title and date

### DIFF
--- a/themes/dxh-blades/layouts/_default/list.html
+++ b/themes/dxh-blades/layouts/_default/list.html
@@ -26,9 +26,6 @@
                     {{ $formattedDate := .Date.Format "2006-01-02" }}
 					<time class="postDate" datetime="{{ $formattedDate }}">{{ $formattedDate }}</time>
                 </div>
-                <div class="postExcerpt">
-                    <p>{{ .Summary }}</p>
-                </div>
             </div>
         </a>
 


### PR DESCRIPTION
This change removes the preview of the post content when viewing the post list-view.

Only the title and date will show on the list-view; this allows the post list to display more neatly. 